### PR TITLE
pagination config modified and pagination & sorting with validation added

### DIFF
--- a/src/main/java/com/kodbook/user/api/UserApi.java
+++ b/src/main/java/com/kodbook/user/api/UserApi.java
@@ -1,18 +1,38 @@
 package com.kodbook.user.api;
 
+import com.kodbook.user.dto.PaginationRequest;
 import com.kodbook.user.dto.UserDto;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+/**
+ * This interface defines the API for user-related operations.
+ * It includes methods for retrieving user information
+ * and paginated lists of users.
+ * The API is versioned as v2.
+ */
 @RequestMapping("/api/v2/users")
 public interface UserApi {
 
+    /**
+     * Returns a user by their ID.
+     *
+     * @param id the ID of the user to return
+     * @return the user with the given ID, or a 404 response if no such user exists
+     */
     @GetMapping("/{id}")
     ResponseEntity<UserDto> getUserById(@PathVariable Long id);
 
+    /**
+     * Retrieves a page of user Dto objects based on the PaginationRequest passed in
+     *
+     * @param paginationRequest the pagination request object
+     * @return a ResponseEntity containing a page of UserDto objects
+     */
     @GetMapping
-    ResponseEntity<Page<UserDto>> getUsers(int pageNumber, int pageSize, String sortDirection, String[] sortBy);
+    ResponseEntity<Page<UserDto>> getUsers(@ParameterObject PaginationRequest paginationRequest);
 }

--- a/src/main/java/com/kodbook/user/config/PaginationConfig.java
+++ b/src/main/java/com/kodbook/user/config/PaginationConfig.java
@@ -1,0 +1,9 @@
+package com.kodbook.user.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+
+@Configuration
+@EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
+public class PaginationConfig {
+}

--- a/src/main/java/com/kodbook/user/controller/v2/UserControllerV2.java
+++ b/src/main/java/com/kodbook/user/controller/v2/UserControllerV2.java
@@ -1,12 +1,14 @@
 package com.kodbook.user.controller.v2;
 
 import com.kodbook.user.api.UserApi;
+import com.kodbook.user.dto.PaginationRequest;
 import com.kodbook.user.dto.UserDto;
 import com.kodbook.user.service.v2.UserServiceV2;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,10 +24,7 @@ public class UserControllerV2 implements UserApi {
     }
 
     @Override
-    public ResponseEntity<Page<UserDto>> getUsers(@RequestParam(defaultValue = "0", required = false) int pageNumber,
-                                                  @RequestParam(defaultValue = "10", required = false) int pageSize,
-                                                  @RequestParam(defaultValue = "ASC", required = false) String sortDirection,
-                                                  @RequestParam(defaultValue = "id", required = false) String[] sortBy) {
-        return ResponseEntity.ok(userService.getUsers(pageNumber, pageSize, sortDirection, sortBy));
+    public ResponseEntity<Page<UserDto>> getUsers(@ModelAttribute @Valid PaginationRequest paginationRequest) {
+        return ResponseEntity.ok(userService.getUsers(paginationRequest));
     }
 }

--- a/src/main/java/com/kodbook/user/dto/PaginationRequest.java
+++ b/src/main/java/com/kodbook/user/dto/PaginationRequest.java
@@ -1,0 +1,31 @@
+package com.kodbook.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+@Schema(description = "Pagination request parameters", implementation = PaginationRequest.class)
+public class PaginationRequest {
+
+    @Min(value = 0, message = "Page number must be 0 or greater")
+    @Schema(description = "Page number (0-based)", example = "0", minimum = "0", defaultValue = "0", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private int pageNumber = 0;
+
+    @Min(value = 1, message = "Page size must be at least 1")
+    @Max(value = 100, message = "Page size must not exceed 100")
+    @Schema(description = "Number of items per page", example = "10", minimum = "1", maximum = "100", defaultValue = "10", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private int pageSize = 10;
+
+
+    @Pattern(regexp = "ASC|DESC", flags = Pattern.Flag.CASE_INSENSITIVE, message = "Sort direction must be either 'ASC' or 'DESC' (case insensitive)")
+    @Schema(description = "Sort direction", example = "ASC", allowableValues = {"ASC", "DESC"}, defaultValue = "ASC", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String sortDirection = "ASC";
+
+    @Size(min = 1, message = "At least one sort property must be specified")
+    @Schema(description = "Properties to sort by", example = "id", defaultValue = "id", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String[] sortBy = {"id"};
+}

--- a/src/main/java/com/kodbook/user/service/v2/UserServiceV2.java
+++ b/src/main/java/com/kodbook/user/service/v2/UserServiceV2.java
@@ -1,5 +1,6 @@
 package com.kodbook.user.service.v2;
 
+import com.kodbook.user.dto.PaginationRequest;
 import com.kodbook.user.dto.UserDto;
 import com.kodbook.user.entity.User;
 import org.springframework.data.domain.Page;
@@ -11,5 +12,5 @@ public interface UserServiceV2 {
 
     UserDto getUserById(Long id);
 
-    Page<UserDto> getUsers(int pageNumber, int pageSize, String sortDirection, String[] sortBy);
+    Page<UserDto> getUsers(PaginationRequest paginationRequest);
 }

--- a/src/main/java/com/kodbook/user/service/v2/impl/UserServiceV2Impl.java
+++ b/src/main/java/com/kodbook/user/service/v2/impl/UserServiceV2Impl.java
@@ -1,6 +1,7 @@
 package com.kodbook.user.service.v2.impl;
 
 import com.kodbook.exception.custom.UsernameNotFoundException;
+import com.kodbook.user.dto.PaginationRequest;
 import com.kodbook.user.dto.UserDto;
 import com.kodbook.user.entity.User;
 import com.kodbook.user.exception.UserIdNotFoundException;
@@ -39,8 +40,8 @@ public class UserServiceV2Impl implements UserServiceV2 {
     }
 
     @Override
-    public Page<UserDto> getUsers(int pageNumber, int pageSize, String sortDirection, String[] sortBy) {
-        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.Direction.fromString(sortDirection), sortBy);
+    public Page<UserDto> getUsers(PaginationRequest paginationRequest) {
+        Pageable pageable = PageRequest.of(paginationRequest.getPageNumber(), paginationRequest.getPageSize(), Sort.Direction.fromString(paginationRequest.getSortDirection()), paginationRequest.getSortBy());
         return userRepository.findAll(pageable).map(userMapper::mapToDto);
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -39,13 +39,13 @@ spring:
             user.name: ${SBA_CLIENT_ACTUATOR_USERNAME}
             user.password: ${SBA_CLIENT_ACTUATOR_PASSWORD}
           service-base-url: ${SBA_CLIENT_BASE_URL}
-#logging configuration
-logging:
-  level:
-    root:
-    org:
-      springframework:
-        security: debug
+  #logging configuration
+  #logging:
+  #  level:
+  #    root:
+  #    org:
+  #      springframework:
+  #        security: debug
   structured:
     format:
       #      console: ecs
@@ -87,7 +87,7 @@ springdoc:
     filter: true
     operationsSorter: method
     tagsSorter: alpha
-    tryItOutEnabled: true
+    tryItOutEnabled: false
   show-actuator: true
   writer-with-default-pretty-printer: true
   default-produces-media-type: application/json


### PR DESCRIPTION
### Pagination & Sorting
1. Pagination and sorting with validation added.
2. Pagination config modified for to overcome  this warning.
```java
WARN 412 --- [kodBook-service] [nio-8081-exec-7] ration$PageModule$WarningLoggingModifier : Serializing PageImpl instances as-is is not supported, meaning that there is no guarantee about the stability of the resulting JSON structure!
	For a stable JSON structure, please use Spring Data's PagedModel (globally via @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO))
	or Spring HATEOAS and Spring Data's PagedResourcesAssembler as documented in https://docs.spring.io/spring-data/commons/reference/repositories/core-extensions.html#core.web.pageables.
``` 
### To Avoid this:
```
@Configuration
@EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
public class PaginationConfig {
}````